### PR TITLE
#77 & #78 Added new functionality for subscriber-only content

### DIFF
--- a/admin/class-tni-core-admin.php
+++ b/admin/class-tni-core-admin.php
@@ -251,6 +251,14 @@ class Tni_Core_Admin {
 		 * class.
 		 */
 		wp_enqueue_script( $this->plugin_name, TNI_CORE_DIR_URL . 'assets/js/admin.js', array( 'jquery-chosen' ), $this->version, false );
+
+		if( function_exists( 'get_current_screen' ) ) {
+			$post_type = get_current_screen()->post_type;
+			if( 'post' === $post_type  ) {
+				wp_enqueue_script( $this->plugin_name . '-acf', TNI_CORE_DIR_URL . 'admin/js/acf.js', array( 'jquery' ), $this->version, true );
+			}
+
+		}
 	}
 
 	/**

--- a/admin/js/acf.js
+++ b/admin/js/acf.js
@@ -1,0 +1,16 @@
+/**
+ * Add JS to ACF Actions
+ *
+ * @see https://www.advancedcustomfields.com/resources/adding-custom-javascript-fields/
+ */
+(function( $ ) {
+	'use strict';
+
+  var $publish = $('#submitdiv');
+  var $subscriber = $('#acf-group_subscriber_content');
+  var $coauthors = $('#coauthorsdiv');
+
+  $subscriber.insertAfter( $publish );
+  $coauthors.insertAfter( $subscriber );
+
+})( jQuery );

--- a/includes/class-tni-core-authorization.php
+++ b/includes/class-tni-core-authorization.php
@@ -70,9 +70,10 @@ class TNI_Core_Authorization {
    * Initialize all the things
    *
    * @since 1.0.9
+   * @since 1.2.8 Added default $version
    *
    */
-  function __construct( $file = '', $version ) {
+  function __construct( $file = '', $version = '1.2.8' ) {
     $this->_version = $version;
 
     // Load plugin environment variables

--- a/includes/class-tni-core-custom-fields.php
+++ b/includes/class-tni-core-custom-fields.php
@@ -85,6 +85,47 @@ class TNI_Core_Custom_Fields {
     		'menu_order' => 0,
     	));
 
+      register_field_group( array (
+      	'key' => 'group_subscriber_content',
+      	'title' => __( 'Subscriber Only Content', 'tni-core' ),
+      	'fields' => array (
+      		array (
+      			'key' => 'field_subscriber_only_date',
+      			'label' => __( 'Date', 'tni-core' ),
+      			'name' => 'subscriber_only_date',
+      			'type' => 'date_picker',
+      			'instructions' => __( 'Select date on which content will be available to non-subscribers.', 'tni-core' ),
+      			'required' => 0,
+      			'conditional_logic' => 0,
+      			'wrapper' => array (
+      				'width' => '',
+      				'class' => '',
+      				'id' => '',
+      			),
+      			'display_format' => 'm/d/Y',
+      			'return_format' => 'd/m/Y',
+      			'first_day' => 1,
+      		),
+      	),
+      	'location' => array (
+      		array (
+      			array (
+      				'param' => 'post_type',
+      				'operator' => '==',
+      				'value' => 'post',
+      			),
+      		),
+      	),
+      	'menu_order' => 0,
+      	'position' => 'side',
+      	'style' => 'default',
+      	'label_placement' => 'top',
+      	'instruction_placement' => 'label',
+      	'hide_on_screen' => '',
+      	'active' => 1,
+      	'description' => '',
+      ));
+
     	register_field_group( array (
     		'id' => 'acf_essay',
     		'title' => __( 'Featured Content', 'tni' ),

--- a/includes/content-filters.php
+++ b/includes/content-filters.php
@@ -45,29 +45,3 @@ function tni_core_future_permalink( $permalink, $post, $leavename, $sample = fal
 }
 add_filter( 'post_link', 'tni_core_future_permalink', 10, 3 );
 add_filter( 'post_type_link', 'tni_core_future_permalink', 10, 4 );
-
-
-/**
- * Show Single Future Posts
- * When posts are scheduled (`post_status` = `future`), show them in single views for authenticated users
- *
- * @since 1.2.6
- *
- * @param  array $posts
- *
- * @return array $posts
- */
-function show_future_posts($posts) {
-   global $wp_query, $wpdb;
-   $auth = tni_core_check_auth();
-   if ($auth && is_single() && empty($posts)) {
-      $posts = $wpdb->get_results($wp_query->request);
-
-      // make sure it only affects future posts, not trashed
-      if(isset($posts[0]->post_status) && $posts[0]->post_status!='future'){
-        $posts=array();
-      }
-   }
-   return $posts;
-}
-add_filter('the_posts', 'show_future_posts');

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -82,3 +82,26 @@ function tni_get_users_meta( $field = null ) {
   sort( $titles );
   return array_unique( $titles );
 }
+
+/**
+ * Is Content Subscriber Only
+ * Checks if content is subscription only today
+ *
+ * @since 1.2.8
+ *
+ * @param int $post
+ * @return bool true|false
+ */
+function tni_is_subscription_only( $post ) {
+  $post = (int) $post;
+
+  $subscription_date = get_post_meta( $post, 'subscriber_only_date', true );
+
+  if( !isset( $subscription_date ) || empty( $subscription_date ) ) {
+    return false;
+  }
+
+  $today = date( 'Ymd' );
+
+  return strtotime( $subscription_date ) > strtotime( $today );
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom
 Requires at least: 4.7
 Tested up to: 4.8
-Version: 1.2.7
+Version: 1.2.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,14 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 1.2.8 July 6, 2017 =
+* #33 Fixed PHP error caused when `TNI_Core_Authorization` class is instantiated without passing required values `$file` and `$version`
+* Added new functionality for subscriber-only content - In single.php template, add conditionals `tni_is_subscription_only` and `tni_core_check_auth` to serve alternate content to non-subscribers
+  * Added `subscriber_only_date` date field
+  * Moved new Subscriber Only Content metabox below publish box on edit screen
+  * Added `tni_is_subscription_only` that returns true or false if content is subscription-only today
+  * Removed `show_future_posts` function since subscription date will be used instead
 
 = 1.2.7 June 22, 2017 =
 * #29 Added `audio_url` custom field.

--- a/tni-core-functionality.php
+++ b/tni-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     tni-core
  * Domain Path:     /languages
  *
- * Version:         1.2.7
+ * Version:         1.2.8
  *
  * @package         Tni_Core_Functionality
  */
@@ -52,7 +52,7 @@ require_once( 'includes/utilities.php' );
  * @return object Tni_Core
  */
 function Tni_Core() {
-	$instance = Tni_Core::instance( __FILE__, 'l.2.7' );
+	$instance = Tni_Core::instance( __FILE__, 'l.2.8' );
 
 	return $instance;
 }


### PR DESCRIPTION
  * Added `subscriber_only_date` date field
  * Moved new Subscriber Only Content metabox below publish box on edit screen
  * Added `tni_is_subscription_only` that returns true or false if content is subscription-only today
  * Removed `show_future_posts` function since subscription date will be used instead

In single.php template, add conditionals `tni_is_subscription_only` and `tni_core_check_auth` to serve alternate content to non-subscribers

Ref: https://github.com/thenewinquiry/tni-theme/issues/77 and https://github.com/thenewinquiry/tni-theme/issues/78