### PR TITLE
1.3.0 -  #40 Post bundles

### DIFF
--- a/admin/class-tni-core-admin.php
+++ b/admin/class-tni-core-admin.php
@@ -158,6 +158,32 @@ class Tni_Core_Admin {
 			 			'max' => 1,
 			 			'return_format' => 'id',
 			 		),
+					/**
+					 * Featured Bundle
+					 * @since 1.3.0
+					 */
+					array (
+						'key' => 'field_featured_bundle',
+						'label' => __( 'Featured Bundle', 'tni-core' ),
+						'name' => 'featured_bundle',
+						'type' => 'taxonomy',
+						'instructions' => '',
+						'required' => 0,
+						'conditional_logic' => 0,
+						'wrapper' => array (
+							'width' => '',
+							'class' => '',
+							'id' => '',
+						),
+						'taxonomy' => 'bundle',
+						'field_type' => 'select',
+						'allow_null' => 1,
+						'add_term' => 1,
+						'save_terms' => 1,
+						'load_terms' => 1,
+						'return_format' => 'id',
+						'multiple' => 0,
+					),
 			 	),
 			 	'location' => array (
 			 		array (

--- a/includes/class-tni-core-taxonomy.php
+++ b/includes/class-tni-core-taxonomy.php
@@ -25,7 +25,8 @@ class TNI_Core_Taxonomy {
      *
      */
     function __construct() {
-        add_action( 'init', array( $this, 'register_taxonomy' ), 0 );
+        add_action( 'init', array( $this, 'register_blog_types' ), 0 );
+        add_action( 'init', array( $this, 'register_bundles' ), 0 );
     }
 
     /**
@@ -33,11 +34,9 @@ class TNI_Core_Taxonomy {
      *
      * @since 1.0.0
      *
-     * @param string $shortcode_tag
-     * @param function $shortcode_function
-     *
+     * @return void
      */
-    public function register_taxonomy() {
+    public function register_blog_types() {
 
         $labels = array(
             'name'                       => _x( 'Types', 'Taxonomy General Name', 'tni-core' ),
@@ -64,6 +63,51 @@ class TNI_Core_Taxonomy {
             'rest_base'                  => 'blogs',
         );
         register_taxonomy( 'blog-types', array( 'blogs' ), apply_filters( 'blog_types_taxonomy_args', $args ) );
+    }
+
+    /**
+     * Register Bundle Taxonomy
+     *
+     * @since 1.3.0
+     *
+     * @return void
+     */
+    function register_bundles() {
+
+    	$labels = array(
+    		'name'                       => _x( 'Bundles', 'Taxonomy General Name', 'tni-core' ),
+    		'singular_name'              => _x( 'Bundle', 'Taxonomy Singular Name', 'tni-core' ),
+    		'menu_name'                  => __( 'Bundle', 'tni-core' ),
+    		'all_items'                  => __( 'All Bundles', 'tni-core' ),
+    		'parent_item'                => __( 'Parent Bundle', 'tni-core' ),
+    		'parent_item_colon'          => __( 'Parent Bundle:', 'tni-core' ),
+    		'new_item_name'              => __( 'New Bundle Name', 'tni-core' ),
+    		'add_new_item'               => __( 'Add New Bundle', 'tni-core' ),
+    		'edit_item'                  => __( 'Edit Bundle', 'tni-core' ),
+    		'update_item'                => __( 'Update Bundle', 'tni-core' ),
+    		'view_item'                  => __( 'View Bundle', 'tni-core' ),
+    		'separate_items_with_commas' => __( 'Separate bundles with commas', 'tni-core' ),
+    		'add_or_remove_items'        => __( 'Add or remove bundles', 'tni-core' ),
+    		'choose_from_most_used'      => __( 'Choose from the most used', 'tni-core' ),
+    		'popular_items'              => __( 'Popular Bundles', 'tni-core' ),
+    		'search_items'               => __( 'Search Bundles', 'tni-core' ),
+    		'not_found'                  => __( 'Not Found', 'tni-core' ),
+    		'no_terms'                   => __( 'No bundles', 'tni-core' ),
+    		'items_list'                 => __( 'Bundles list', 'tni-core' ),
+    		'items_list_navigation'      => __( 'Bundles list navigation', 'tni-core' ),
+    	);
+    	$args = array(
+    		'labels'                     => apply_filters( 'bundles_taxonomy_labels', $labels ),
+    		'hierarchical'               => false,
+    		'public'                     => true,
+    		'show_ui'                    => true,
+    		'show_admin_column'          => true,
+    		'show_in_nav_menus'          => true,
+    		'show_tagcloud'              => true,
+    		'show_in_rest'               => true,
+    	);
+    	register_taxonomy( 'bundle', array( 'post' ), apply_filters( 'bundle_taxonomy_args', $args ) );
+
     }
 
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -149,6 +149,51 @@ function tni_core_get_unauthorized_posts() {
 }
 
 /**
+ * Get the Featured Bundle Posts
+ * If there is a featured Bundle return the posts in the bundle
+ *
+ * @since 1.3.0
+ *
+ * @return mixed array $posts || false
+ */
+function tni_core_get_featured_bundle_posts() {
+  if( $featured_bundle = get_option( 'options_featured_bundle' ) ) {
+
+    $posts = get_transient( 'tni_featured_bundle_posts' );
+
+    if( false === $posts ) {
+
+      $args = array(
+        'fields'          => 'ids',
+        'posts_per_page'  => -1,
+        'tax_query'       => array(
+          array(
+            'taxonomy'    => 'bundle',
+            'field'       => 'term_id',
+            'terms'       => array( (int) $featured_bundle )
+          )
+        )
+      );
+      $query = new WP_Query( $args );
+      $post_query = $query->get_posts();
+
+      if( !empty( $post_query ) || !is_wp_error( $post_query ) ) {
+        $posts =  $post_query;
+      }
+
+      set_transient( 'tni_featured_bundle_posts', $posts, MINUTE_IN_SECONDS * 5 );
+
+    }
+
+    return $posts;
+
+  }
+
+  return false;
+
+}
+
+/**
  * Purge Transients
  * Each time a post is published, delete the transient
  * Note: It will not run when a post is updated

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom
 Requires at least: 4.7
 Tested up to: 4.8.2
-Version: 1.2.13
+Version: 1.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,12 @@ This section describes how to install the plugin and get it working.
 1. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 1.3.0 October 29, 2017 =
+* #40 Post bundles
+  * Added Bundles taxonomy
+  * Added option to select featured bundle to Featured Content page
+  * Added function to get list of posts in featured bundle
 
 = 1.2.13 October 10, 2017 =
 * #38 Checkbox for subscriber only content @link https://github.com/thenewinquiry/tni-core-functionality/issues/38

--- a/tni-core-functionality.php
+++ b/tni-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     tni-core
  * Domain Path:     /languages
  *
- * Version:         1.2.13
+ * Version:         1.3.0
  *
  * @package         Tni_Core_Functionality
  */
@@ -52,7 +52,7 @@ require_once( 'includes/utilities.php' );
  * @return object Tni_Core
  */
 function Tni_Core() {
-	$instance = Tni_Core::instance( __FILE__, 'l.2.13' );
+	$instance = Tni_Core::instance( __FILE__, 'l.3.0' );
 
 	return $instance;
 }


### PR DESCRIPTION
#40 Bundled Posts
  * Added query to get bundled posts on home page
  * Updated `template-parts/content.php` template to display linked bundle name in place of category
  * Filtered home page query to exclude featured bundle posts