### PR TITLE
#44 Add `bundle` taxonomy to `blogs` post type

### DIFF
--- a/includes/class-tni-core-taxonomy.php
+++ b/includes/class-tni-core-taxonomy.php
@@ -106,7 +106,7 @@ class TNI_Core_Taxonomy {
     		'show_tagcloud'              => true,
     		'show_in_rest'               => true,
     	);
-    	register_taxonomy( 'bundle', array( 'post' ), apply_filters( 'bundle_taxonomy_args', $args ) );
+    	register_taxonomy( 'bundle', array( 'post', 'blogs' ), apply_filters( 'bundle_taxonomy_args', $args ) );
 
     }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -165,6 +165,7 @@ function tni_core_get_featured_bundle_posts() {
 
       $args = array(
         'fields'          => 'ids',
+        'post_type' => array( 'post', 'blogs' ),
         'posts_per_page'  => -1,
         'tax_query'       => array(
           array(

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,8 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.3.2 Novembmer 6, 2017 =
+
 = 1.3.1 October 30, 2017 =
 * #95 SEO customization for JetPack @link https://github.com/thenewinquiry/tni-theme/issues/95
   * Added Twitter Description (`seo_description_twitter`) field

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: misfist
 Tags: custom
 Requires at least: 4.7
 Tested up to: 4.8.2
-Version: 1.3.1
+Version: 1.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ This section describes how to install the plugin and get it working.
 == Changelog ==
 
 = 1.3.2 Novembmer 6, 2017 =
+* #44 Added `bundle` taxonomy to `blogs` post type @link https://github.com/thenewinquiry/tni-core-functionality/issues/44
+  * Added `blogs` to `bundle`
+  * Included `blogs` post type in `tni_core_get_featured_bundle_posts()`
 
 = 1.3.1 October 30, 2017 =
 * #95 SEO customization for JetPack @link https://github.com/thenewinquiry/tni-theme/issues/95

--- a/tni-core-functionality.php
+++ b/tni-core-functionality.php
@@ -10,7 +10,7 @@
  * Text Domain:     tni-core
  * Domain Path:     /languages
  *
- * Version:         1.3.1
+ * Version:         1.3.2
  *
  * @package         Tni_Core_Functionality
  */
@@ -52,7 +52,7 @@ require_once( 'includes/utilities.php' );
  * @return object Tni_Core
  */
 function Tni_Core() {
-	$instance = Tni_Core::instance( __FILE__, 'l.3.1' );
+	$instance = Tni_Core::instance( __FILE__, 'l.3.2' );
 
 	return $instance;
 }


### PR DESCRIPTION
#44 Added `bundle` taxonomy to `blogs` post type @link https://github.com/thenewinquiry/tni-core-functionality/issues/44
   * Added `blogs` to `bundle`
   * Included `blogs` post type in `tni_core_get_featured_bundle_posts()`